### PR TITLE
Avoid ArrayIndexOutOfBoundsException

### DIFF
--- a/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
+++ b/commons/src/main/java/com/afollestad/materialdialogs/color/ColorChooserDialog.java
@@ -343,6 +343,7 @@ public class ColorChooserDialog extends DialogFragment implements View.OnClickLi
                         if (isInSub()) {
                             dialog.setActionButton(DialogAction.NEGATIVE, getBuilder().mCancelBtn);
                             isInSub(false);
+                            subIndex(-1); // Do this to avoid ArrayIndexOutOfBoundsException
                             invalidate();
                         } else {
                             dialog.cancel();


### PR DESCRIPTION
When the user navigates back to topColors after having selected a subColor, and then navigates to a subColor menu that does not have as many subColors as the index chosen previously, an ArrayIndexOutOfBoundsException is thrown.
Moreover, this presents consistent behavior to the user in that the index chosen for subColors under one topColor does not affect another.